### PR TITLE
Support for /+ +/ comments

### DIFF
--- a/grammars/d.cson
+++ b/grammars/d.cson
@@ -394,6 +394,14 @@
   'comments-inline':
     'patterns': [
       {
+        'begin': '/\\+'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.d'
+        'end': '\\+/'
+        'name': 'comment.block.d'
+      }
+      {
         'begin': '/\\*'
         'captures':
           '0':


### PR DESCRIPTION
A lot of files in phobos (e.g. algorithm.d) are wrongly highlighted, because of /+ block contains ' char. This change seems to fix this.
