### PR TITLE
Fix matching order

### DIFF
--- a/grammars/d.cson
+++ b/grammars/d.cson
@@ -415,44 +415,40 @@
         'name': 'keyword.operator.d'
       }
       {
-        'match': '='
-        'name': 'keyword.operator.assignment.d'
-      }
-      {
-        'match': '[\\+\\-\\*/%]'
-        'name': 'keyword.operator.arithmetic.d'
+        'match': '(\\-\\-|\\+\\+)'
+        'name': 'keyword.operator.increment-decrement.d'
       }
       {
         'match': '[\\+\\-\\*/%]='
         'name': 'keyword.operator.assignment.arithmetic.d'
       }
       {
-        'match': '(\\-\\-|\\+\\+)'
-        'name': 'keyword.operator.increment-decrement.d'
+        'match': '[\\+\\-\\*/%]'
+        'name': 'keyword.operator.arithmetic.d'
       }
       {
         'match': '\\^\\^'
         'name': 'keyword.operator.power.d'
       }
       {
-        'match': '<<|>>?|\\||\\^|&'
-        'name': 'keyword.operator.bitwise.d'
+        'match': '(&&|\\|\\|)'
+        'name': 'keyword.operator.logical.d'
       }
       {
         'match': '(<<|>>?|\\||\\^|&)='
         'name': 'keyword.operator.assignment.bitwise.d'
       }
       {
-        'match': '(&&|\\|\\|)'
-        'name': 'keyword.operator.logical.d'
-      }
-      {
-        'match': '!(?!\\s*\\()'
-        'name': 'keyword.operator.logical.d'
+        'match': '(<<|>>?|\\||\\^|&)'
+        'name': 'keyword.operator.bitwise.d'
       }
       {
         'match': '(==|!=|<=|>=|<>|<|>)'
         'name': 'keyword.operator.comparison.d'
+      }
+      {
+        'match': '!(?!\\s*\\()'
+        'name': 'keyword.operator.logical.d'
       }
       {
         'match': '[\\?:]'
@@ -463,16 +459,20 @@
         'name': 'keyword.operator.dereference.d'
       }
       {
-        'match': '~'
-        'name': 'keyword.operator.concatenation.d'
-      }
-      {
         'match': '~='
         'name': 'keyword.operator.assignment.concatenation.d'
       }
       {
+        'match': '~'
+        'name': 'keyword.operator.concatenation.d'
+      }
+      {
         'match': '=>'
         'name': 'keyword.operator.lambda.d'
+      }
+      {
+        'match': '='
+        'name': 'keyword.operator.assignment.d'
       }
       {
         'match': ','


### PR DESCRIPTION
The problem was that >= was matched as two separate operators and ligatures didn't work. I reordered the matching order of the operators so that everything gets properly matched. Fixes #9 