### PR TITLE
Fix strings in template instantiations (ctRegex!(`...`)) causing the …

### DIFF
--- a/grammars/d.cson
+++ b/grammars/d.cson
@@ -656,6 +656,9 @@
           {
             'include': '#constants-and-special-vars'
           }
+          {
+            'include': '#strings'
+          }
         ]
       }
     ]


### PR DESCRIPTION
When using ctRegex!(``), the entire rest of the file would incorrectly be syntax highlighted as being inside a string. This fixes it by adding strings to the template instantiation pattern's patterns.