### PR TITLE
Add highlighting to keywords like immutable.

### DIFF
--- a/grammars/d.cson
+++ b/grammars/d.cson
@@ -596,7 +596,7 @@
       }
       {
         'match': '\\b(const|immutable|inout|shared)\\b'
-        'name': 'storage.modifier.qualifier.d'
+        'name': 'keyword.declaration.d'
       }
     ]
   'unittests':


### PR DESCRIPTION
The inital 
`'name': 'storage.modifier.qualifier.d'`

would not be highlighted. Therefore I used keyword.declaration.d